### PR TITLE
Add gnosis endpoint, Fix SOR issues

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -161,6 +161,11 @@ export class BalancerPoolsAPI extends Stack {
     const sorOnChain = sor.addResource('{chainId}')
     sorOnChain.addMethod('POST', runSORIntegration);
     addCorsOptions(sor);
+
+    const gnosis = api.root.addResource('gnosis');
+    const gnosisOnChain = gnosis.addResource('{chainId}')
+    gnosisOnChain.addMethod('POST', runSORIntegration);
+    addCorsOptions(gnosis);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-cdk/aws-lambda": "^1.135.0",
         "@aws-cdk/aws-lambda-nodejs": "^1.135.0",
         "@aws-cdk/core": "^1.135.0",
-        "@balancer-labs/sor": "^2.0.0-beta.8",
+        "@balancer-labs/sor": "^2.1.0-beta.1",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "aws-sdk": "^2.1035.0",
@@ -1644,11 +1644,11 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "2.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-2.0.0-beta.8.tgz",
-      "integrity": "sha512-4bUXZzG6W9VLbHGhAm4r4QvgnQfP9uIxs05bx/QeM7+4RjgWwUVW7nIMpGBC5BC6uPrMfEwxLWQZthZU9qsBkw==",
+      "version": "2.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-2.1.0-beta.1.tgz",
+      "integrity": "sha512-EJlzX43qeChY8n1mh99B2ZaqyNL+ozJda0CeeR+4MOcAjs4bnOiG2LT0TWv7L9LFpFbAosSwXroXLn4k/exFXA==",
       "dependencies": {
-        "@georgeroman/balancer-v2-pools": "^0.0.5",
+        "@georgeroman/balancer-v2-pools": "^0.0.7",
         "isomorphic-fetch": "^2.2.1"
       },
       "peerDependencies": {
@@ -1677,10 +1677,6 @@
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
       }
-    },
-    "node_modules/@balancer-labs/v2-deployments": {
-      "version": "1.1.1",
-      "integrity": "sha512-emB/xHCM/njxpReZQx2BqzHXwrWF+iIwn/hSwnSOxp+P6GH0rOaboio6/+Aapj7f9tCCjqRspetX//9TumX82Q=="
     },
     "node_modules/@cspotcode/source-map-consumer": {
       "version": "0.8.0",
@@ -2361,10 +2357,10 @@
       }
     },
     "node_modules/@georgeroman/balancer-v2-pools": {
-      "version": "0.0.5",
-      "integrity": "sha512-fx+QmDJ80+E4RoaBfmnKFaOlRLM/FSbzksaTrqXM+0EeWX5Zu99SO03pjTIBDsBifq2WfHBcCU5CW5ulGF/kkg==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@georgeroman/balancer-v2-pools/-/balancer-v2-pools-0.0.7.tgz",
+      "integrity": "sha512-tlEbAun1Fjwa/GFKBYwO3/IfkhemyyZ16DJjKStstYVOF2X+Tka7AHaAc3Xi3o/a4TWD1/NrRAI98PSzAGVQ8Q==",
       "dependencies": {
-        "@balancer-labs/v2-deployments": "^1.0.0",
         "bignumber.js": "^9.0.1",
         "ethers": "^5.2.0",
         "graphql": "^15.5.0",
@@ -2825,6 +2821,7 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/aws-cdk": {
@@ -4492,7 +4489,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4561,6 +4559,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4643,6 +4642,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -4654,7 +4654,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/constructs": {
       "version": "3.3.161",
@@ -4698,6 +4699,7 @@
     },
     "node_modules/cross-fetch": {
       "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
       "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
       "dependencies": {
         "node-fetch": "2.6.1"
@@ -4748,6 +4750,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "engines": {
         "node": ">=0.4.0"
@@ -5186,6 +5189,7 @@
     },
     "node_modules/extract-files": {
       "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
       "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
       "engines": {
         "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
@@ -5321,6 +5325,7 @@
     },
     "node_modules/form-data": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -5434,22 +5439,24 @@
       }
     },
     "node_modules/graphql": {
-      "version": "15.7.2",
-      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "engines": {
         "node": ">= 10.x"
       }
     },
     "node_modules/graphql-request": {
-      "version": "3.6.1",
-      "integrity": "sha512-Nm1EasrAQVZllyNTlHDLnLZjlhC6eRWnWP6KH//ytnAL08pjlLkdI2K+s6OV92p45hn5b/kUlLbDwACmRoLwrQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.7.0.tgz",
+      "integrity": "sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==",
       "dependencies": {
         "cross-fetch": "^3.0.6",
         "extract-files": "^9.0.0",
         "form-data": "^3.0.0"
       },
       "peerDependencies": {
-        "graphql": "14.x || 15.x"
+        "graphql": "14 - 16"
       }
     },
     "node_modules/has-flag": {
@@ -5685,6 +5692,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5776,6 +5784,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6097,6 +6106,7 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6518,7 +6528,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yn": {
       "version": "3.1.1",
@@ -7423,11 +7434,11 @@
       "integrity": "sha512-tIZn0/l6T+RXMKyGoke68UTQ7zt3xpqiH3myY56MHsEKcos3tn3pM3+JsXFZ/Yo2DfwKsAiY5rPd0qMk46Jj7A=="
     },
     "@balancer-labs/sor": {
-      "version": "2.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-2.0.0-beta.8.tgz",
-      "integrity": "sha512-4bUXZzG6W9VLbHGhAm4r4QvgnQfP9uIxs05bx/QeM7+4RjgWwUVW7nIMpGBC5BC6uPrMfEwxLWQZthZU9qsBkw==",
+      "version": "2.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-2.1.0-beta.1.tgz",
+      "integrity": "sha512-EJlzX43qeChY8n1mh99B2ZaqyNL+ozJda0CeeR+4MOcAjs4bnOiG2LT0TWv7L9LFpFbAosSwXroXLn4k/exFXA==",
       "requires": {
-        "@georgeroman/balancer-v2-pools": "^0.0.5",
+        "@georgeroman/balancer-v2-pools": "^0.0.7",
         "isomorphic-fetch": "^2.2.1"
       },
       "dependencies": {
@@ -7450,10 +7461,6 @@
           }
         }
       }
-    },
-    "@balancer-labs/v2-deployments": {
-      "version": "1.1.1",
-      "integrity": "sha512-emB/xHCM/njxpReZQx2BqzHXwrWF+iIwn/hSwnSOxp+P6GH0rOaboio6/+Aapj7f9tCCjqRspetX//9TumX82Q=="
     },
     "@cspotcode/source-map-consumer": {
       "version": "0.8.0",
@@ -7825,10 +7832,10 @@
       }
     },
     "@georgeroman/balancer-v2-pools": {
-      "version": "0.0.5",
-      "integrity": "sha512-fx+QmDJ80+E4RoaBfmnKFaOlRLM/FSbzksaTrqXM+0EeWX5Zu99SO03pjTIBDsBifq2WfHBcCU5CW5ulGF/kkg==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@georgeroman/balancer-v2-pools/-/balancer-v2-pools-0.0.7.tgz",
+      "integrity": "sha512-tlEbAun1Fjwa/GFKBYwO3/IfkhemyyZ16DJjKStstYVOF2X+Tka7AHaAc3Xi3o/a4TWD1/NrRAI98PSzAGVQ8Q==",
       "requires": {
-        "@balancer-labs/v2-deployments": "^1.0.0",
         "bignumber.js": "^9.0.1",
         "ethers": "^5.2.0",
         "graphql": "^15.5.0",
@@ -8165,6 +8172,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-cdk": {
@@ -9844,7 +9852,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -9895,6 +9904,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9959,6 +9969,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -9967,7 +9978,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "constructs": {
       "version": "3.3.161",
@@ -9999,6 +10011,7 @@
     },
     "cross-fetch": {
       "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
       "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
       "requires": {
         "node-fetch": "2.6.1"
@@ -10037,6 +10050,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
@@ -10377,6 +10391,7 @@
     },
     "extract-files": {
       "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
       "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ=="
     },
     "fast-deep-equal": {
@@ -10492,6 +10507,7 @@
     },
     "form-data": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "requires": {
         "asynckit": "^0.4.0",
@@ -10574,12 +10590,14 @@
       }
     },
     "graphql": {
-      "version": "15.7.2",
-      "integrity": "sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A=="
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
     },
     "graphql-request": {
-      "version": "3.6.1",
-      "integrity": "sha512-Nm1EasrAQVZllyNTlHDLnLZjlhC6eRWnWP6KH//ytnAL08pjlLkdI2K+s6OV92p45hn5b/kUlLbDwACmRoLwrQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.7.0.tgz",
+      "integrity": "sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==",
       "requires": {
         "cross-fetch": "^3.0.6",
         "extract-files": "^9.0.0",
@@ -10776,6 +10794,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -10840,6 +10859,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11050,6 +11070,7 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -11347,7 +11368,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@aws-cdk/aws-lambda": "^1.135.0",
     "@aws-cdk/aws-lambda-nodejs": "^1.135.0",
     "@aws-cdk/core": "^1.135.0",
-    "@balancer-labs/sor": "^2.0.0-beta.8",
+    "@balancer-labs/sor": "^2.1.0-beta.1",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "aws-sdk": "^2.1035.0",

--- a/src/sor.ts
+++ b/src/sor.ts
@@ -67,12 +67,18 @@ export async function getSorSwap(chainId: number, order: Order): Promise<SwapInf
   const { sellToken, buyToken, orderKind, amount, gasPrice } = order;
 
   const sellTokenDetails: Token = await getToken(chainId, sellToken);
-  log(`Got sell token details for token ${chainId} ${sellToken}: ${JSON.stringify(sellTokenDetails)}`)
+  log(`Sell token details for token ${chainId} ${sellToken}: ${JSON.stringify(sellTokenDetails)}`)
   const buyTokenDetails: Token = await getToken(chainId, buyToken);
-  log(`Got buy token details for token ${chainId} ${buyToken}: ${JSON.stringify(buyTokenDetails)}`)
+  log(`Buy token details for token ${chainId} ${buyToken}: ${JSON.stringify(buyTokenDetails)}`)
 
-  sor.swapCostCalculator.setNativeAssetPriceInToken(sellToken, sellTokenDetails.price);
-  sor.swapCostCalculator.setNativeAssetPriceInToken(buyToken, buyTokenDetails.price);
+
+  if (sellTokenDetails) {
+    sor.swapCostCalculator.setNativeAssetPriceInToken(sellToken, sellTokenDetails.price);
+  }
+
+  if (buyTokenDetails) {
+    sor.swapCostCalculator.setNativeAssetPriceInToken(buyToken, buyTokenDetails.price);
+  }
 
   const tokenIn = sellToken;
   const tokenOut = buyToken;
@@ -84,9 +90,12 @@ export async function getSorSwap(chainId: number, order: Order): Promise<SwapInf
 
   await sor.fetchPools(pools, false);
 
+  const buyTokenSymbol = buyTokenDetails ? buyTokenDetails.symbol : buyToken;
+  const sellTokenSymbol = sellTokenDetails ? sellTokenDetails.symbol : sellToken;
+
   log(
-    `${orderKind}ing ${amount} ${sellTokenDetails.symbol}` +
-      ` for ${buyTokenDetails.symbol}`
+    `${orderKind}ing ${amount} ${sellTokenSymbol}` +
+      ` for ${buyTokenSymbol}`
   );
   log(orderKind);
   log(`Token In: ${tokenIn}`);

--- a/src/sor.ts
+++ b/src/sor.ts
@@ -1,6 +1,6 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { SOR, SwapInfo, SubgraphPoolBase, SwapOptions } from "@balancer-labs/sor";
-import { Order, Token, Pool } from "./types";
+import { Order, Token, Pool, SerializedSwapInfo } from "./types";
 import { 
   getTokenInfo, 
   orderKindToSwapType,
@@ -51,7 +51,24 @@ export async function fetchTokens(chainId: number, tokenAddresses: string[]): Pr
   return tokens;
 }
 
-export async function getSorSwap(chainId: number, order: Order): Promise<SwapInfo> {
+function serializeSwapInfo(swapInfo: SwapInfo): SerializedSwapInfo {
+  const serializedSwapInfo: SerializedSwapInfo = {
+    tokenAddresses: swapInfo.tokenAddresses,
+    swaps: swapInfo.swaps,
+    swapAmount: swapInfo.swapAmount.toString(),
+    swapAmountForSwaps: swapInfo.swapAmountForSwaps ? swapInfo.swapAmountForSwaps.toString() : '',
+    returnAmount: swapInfo.returnAmount.toString(),
+    returnAmountFromSwaps: swapInfo.returnAmountFromSwaps ? swapInfo.returnAmountFromSwaps.toString() : '',
+    returnAmountConsideringFees: swapInfo.returnAmountConsideringFees.toString(),
+    tokenIn: swapInfo.tokenIn,
+    tokenOut: swapInfo.tokenOut,
+    marketSp: swapInfo.marketSp
+  };
+
+  return serializedSwapInfo;
+}
+
+export async function getSorSwap(chainId: number, order: Order): Promise<SerializedSwapInfo> {
   log(`Getting swap: ${JSON.stringify(order)}`);
   const infuraUrl = getInfuraUrl(chainId);
   const provider: any = new JsonRpcProvider(infuraUrl);
@@ -113,6 +130,10 @@ export async function getSorSwap(chainId: number, order: Order): Promise<SwapInf
   log(swapInfo.swaps);
   log(swapInfo.tokenAddresses);
   log(swapInfo.returnAmount.toString());
-  return swapInfo;
+
+  const serializedSwapInfo = serializeSwapInfo(swapInfo);
+  log(`Serialized SwapInfo: ${JSON.stringify(swapInfo)}`);
+
+  return serializedSwapInfo;
 }
 

--- a/src/sor.ts
+++ b/src/sor.ts
@@ -91,10 +91,16 @@ export async function getSorSwap(chainId: number, order: Order): Promise<Seriali
 
   if (sellTokenDetails) {
     sor.swapCostCalculator.setNativeAssetPriceInToken(sellToken, sellTokenDetails.price);
+  } else {
+    log(`No price found for token ${sellToken}. Defaulting to 0.`)
+    sor.swapCostCalculator.setNativeAssetPriceInToken(sellToken, '0');
   }
 
   if (buyTokenDetails) {
     sor.swapCostCalculator.setNativeAssetPriceInToken(buyToken, buyTokenDetails.price);
+  } else {
+    log(`No price found for token ${buyToken}. Defaulting to 0.`)
+    sor.swapCostCalculator.setNativeAssetPriceInToken(buyToken, '0');
   }
 
   const tokenIn = sellToken;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,12 +21,16 @@ export interface Order {
     gasPrice: string;
 }
 
+// price is the price of the native asset (ETH, MATIC, etc) 
+// with the token as the base 
+// e.g. with ETH at $20000, WBTC at $50000 
+// USDC would be 20000, WBTC would be 0.4
 export interface Token {
     address: string;
     chainId: number;
     decimals: number;
     symbol: string;
-    price: string; // Price of the token in the native asset (ETH, MATIC, etc)
+    price: string; 
     lastUpdate?: number;
     noPriceData?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-import { SubgraphPoolBase } from '@balancer-labs/sor';
+import { SubgraphPoolBase, SwapV2 } from '@balancer-labs/sor';
+import { BigNumber } from '@ethersproject/bignumber';
 
 export const Network = {
     MAINNET: 1,
@@ -28,6 +29,19 @@ export interface Token {
     price: string; // Price of the token in the native asset (ETH, MATIC, etc)
     lastUpdate?: number;
     noPriceData?: boolean;
+}
+
+export interface SerializedSwapInfo {
+    tokenAddresses: string[];
+    swaps: SwapV2[];
+    swapAmount: string;
+    swapAmountForSwaps?: string;
+    returnAmount: string;
+    returnAmountFromSwaps?: string;
+    returnAmountConsideringFees: string;
+    tokenIn: string;
+    tokenOut: string;
+    marketSp: string;
 }
 
 export interface Pool extends SubgraphPoolBase {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -24,10 +24,10 @@ const lastBlockNumber = {}
 
 function doWork() {
   log(`Working...`);
-  // Object.values(Network).forEach(async (chainId) => {
-  //   lastBlockNumber[chainId] = 0;
-  //   fetchAndSavePools(chainId);
-  // });
+  Object.values(Network).forEach(async (chainId) => {
+    lastBlockNumber[chainId] = 0;
+    fetchAndSavePools(chainId);
+  });
   updatePrices();
 }
 


### PR DESCRIPTION
- Adds a new `/gnosis/{chainId}` endpoint that is currently the same as `/sor/{chainId}`. This is so if we want to make changes to sor but don't want to break gnosis we can make those changes independently. 
- Upgrade SOR to 2.1.0
- Fix SOR crashing when there was no price information on a token.
- Serialize the SOR output so that BigNumbers are returned as strings instead of that strange BigNumber object. 