### PR TITLE
Add CORS headers to pools lambdas

### DIFF
--- a/lambdas/get-pools.ts
+++ b/lambdas/get-pools.ts
@@ -6,10 +6,16 @@ export const handler = async (event: any = {}): Promise<any> => {
     return { statusCode: 400, body: `Error: You are missing the chainId` };
   }
 
+  const corsHeaders = {
+    "Access-Control-Allow-Headers" : "Content-Type",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "OPTIONS,GET"
+  }
+
   try {
     const pools = await getPools(chainId);
-    return { statusCode: 200, body: JSON.stringify(pools) };
+    return { statusCode: 200, headers: corsHeaders, body: JSON.stringify(pools) };
   } catch (dbError) {
-    return { statusCode: 500, body: JSON.stringify(dbError) };
+    return { statusCode: 500, headers: corsHeaders, body: JSON.stringify(dbError) };
   }
 };


### PR DESCRIPTION
Add CORS headers so that the pools API can be used by the frontend. Will add more specific domains in the future. 