### PR TITLE
Add INFURA_PROJECT_ID env variable to Deploy Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,3 +27,5 @@ jobs:
         AWS_REGION: ${{ secrets.AWS_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }} 
+


### PR DESCRIPTION
This is used by the `updatePools` lambda function to load pool data from infura. 

I'm currently using my own key as I believe the production key is locked to specific domains. It uses less requests than the free tier limit. 