### PR TITLE
Add ability to specify a custom domain for API Gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,6 @@ SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2
 PORT=8890
 MAX_POOLS=4
 INFURA_PROJECT_ID=
+DOMAIN_NAME=
 POOLS_API_DDB_READ_CAPACITY=10
 POOLS_API_DDB_WRITE_CAPACITY=10

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-cdk/aws-apigateway": "^1.151.0",
+        "@aws-cdk/aws-certificatemanager": "1.151",
         "@aws-cdk/aws-dynamodb": "^1.151.0",
         "@aws-cdk/aws-events-targets": "^1.151.0",
         "@aws-cdk/aws-lambda": "^1.151.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "@aws-cdk/aws-apigateway": "^1.151.0",
+    "@aws-cdk/aws-certificatemanager": "^1.151.0",
     "@aws-cdk/aws-dynamodb": "^1.151.0",
     "@aws-cdk/aws-events-targets": "^1.151.0",
     "@aws-cdk/aws-lambda": "^1.151.0",


### PR DESCRIPTION
Add the ability to set the environment variable DOMAIN_NAME which will configure that domain/subdomain to route to the API. 

When DOMAIN_NAME is specified and this template is deployed AWS will send an email to the domain owner asking them to confirm the certificate creation for the domain/subdomain, and will halt deployment until that step is complete. 

Tested by creating a creating https://balapi.timjrobinson.com which points to this stack running in my dev account and it works correctly. 