### PR TITLE
Bump SDK to version with ERC4626 support.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-cdk/aws-lambda": "^1.151.0",
         "@aws-cdk/aws-lambda-nodejs": "^1.151.0",
         "@aws-cdk/core": "^1.151.0",
-        "@balancer-labs/sdk": "^0.1.3",
+        "@balancer-labs/sdk": "^0.1.6",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "aws-sdk": "^2.1035.0",
@@ -2205,11 +2205,11 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.5.tgz",
-      "integrity": "sha512-NPHeFCjeCQGrSGLrUZE0vYHEURQ2WAtUl5kMQjewNHcooPAwmIC98N1GQfilH4Or8XcDTgbskZ0vednIAsYbnA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.6.tgz",
+      "integrity": "sha512-r9s7Y2XJks+8V53kqwaqHDAETipgFSEQxI7TFHYigoOtWp/sUaZnlu0kDMv3NuDvya0+t9gp5a0VxbztLwcn+g==",
       "dependencies": {
-        "@balancer-labs/sor": "^4.0.0-beta.1",
+        "@balancer-labs/sor": "^4.0.0-beta.2",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
         "graphql-request": "^3.5.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.0-beta.1.tgz",
-      "integrity": "sha512-L3eMBRA51egMNKHkLktOr3sNJuqgoz24AfJkpzU4w1I66m9HlOPY/E3FgYKWO+1cXJ2sQZWDH3pEjnWMRnNbNg==",
+      "version": "4.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.0-beta.2.tgz",
+      "integrity": "sha512-ylDxsMDKpoynOQIH4PhucYc7bkXddjL6GRFCF2BwnQ4Yoy7vBOT7S0zJvIkKuUG6MSUdoTBaAtWckxXBJiNxyA==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1"
       },
@@ -10468,11 +10468,11 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.5.tgz",
-      "integrity": "sha512-NPHeFCjeCQGrSGLrUZE0vYHEURQ2WAtUl5kMQjewNHcooPAwmIC98N1GQfilH4Or8XcDTgbskZ0vednIAsYbnA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.6.tgz",
+      "integrity": "sha512-r9s7Y2XJks+8V53kqwaqHDAETipgFSEQxI7TFHYigoOtWp/sUaZnlu0kDMv3NuDvya0+t9gp5a0VxbztLwcn+g==",
       "requires": {
-        "@balancer-labs/sor": "^4.0.0-beta.1",
+        "@balancer-labs/sor": "^4.0.0-beta.2",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
         "graphql-request": "^3.5.0",
@@ -10480,9 +10480,9 @@
       }
     },
     "@balancer-labs/sor": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.0-beta.1.tgz",
-      "integrity": "sha512-L3eMBRA51egMNKHkLktOr3sNJuqgoz24AfJkpzU4w1I66m9HlOPY/E3FgYKWO+1cXJ2sQZWDH3pEjnWMRnNbNg==",
+      "version": "4.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.0-beta.2.tgz",
+      "integrity": "sha512-ylDxsMDKpoynOQIH4PhucYc7bkXddjL6GRFCF2BwnQ4Yoy7vBOT7S0zJvIkKuUG6MSUdoTBaAtWckxXBJiNxyA==",
       "requires": {
         "isomorphic-fetch": "^2.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@aws-cdk/aws-lambda": "^1.151.0",
     "@aws-cdk/aws-lambda-nodejs": "^1.151.0",
     "@aws-cdk/core": "^1.151.0",
-    "@balancer-labs/sdk": "^0.1.3",
+    "@balancer-labs/sdk": "^0.1.6",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "aws-sdk": "^2.1035.0",


### PR DESCRIPTION
Bump SDK version to support ERC4626 linear pools.
Shouldn't be any other changes required.