### PR TITLE
Only allow one update-pools lambda to run at once

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -95,7 +95,8 @@ export class BalancerPoolsAPI extends Stack {
       entry: join(__dirname, 'lambdas', 'update-pools.ts'),
       ...nodeJsFunctionProps,
       memorySize: 512,
-      timeout: Duration.seconds(60)
+      timeout: Duration.seconds(60),
+      reservedConcurrentExecutions: 1
     });
     
     const updateTokenPricesLambda = new NodejsFunction(this, 'updateTokenPricesFunction', {


### PR DESCRIPTION
The update pools lambda is triggered every time a new transaction is made to the Balancer vault. Lately there has been a lot of transactions in rapid succession which is making it be called many times and send many requests to infura. It's not neccessary for more than one instance of this lambda to run at a time as all calls do the same thing of fetching and saving all pool + token information. 