### PR TITLE
Add lambda to perform sanctions check for frontend

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -106,6 +106,11 @@ export class BalancerPoolsAPI extends Stack {
       timeout: Duration.seconds(60)
     });
 
+    const sanctionsCheckLambda = new NodejsFunction(this, 'sanctionsCheckFunction', {
+      entry: join(__dirname, 'lambdas', 'sanctions-check.ts'),
+      ...nodeJsFunctionProps
+    });
+
     /** 
      * Lambda Schedules
      */
@@ -140,6 +145,7 @@ export class BalancerPoolsAPI extends Stack {
     const runSORIntegration = new LambdaIntegration(runSORLambda);
     const updatePoolsIntegration = new LambdaIntegration(updatePoolsLambda, {timeout: Duration.seconds(29)});
     const updateTokenPricesIntegration = new LambdaIntegration(updateTokenPricesLambda, {timeout: Duration.seconds(29)});
+    const sanctionsCheckIntegration = new LambdaIntegration(sanctionsCheckLambda);
 
     const api = new RestApi(this, 'poolsApi', {
       restApiName: 'Pools Service'
@@ -176,6 +182,10 @@ export class BalancerPoolsAPI extends Stack {
     const gnosisOnChain = gnosis.addResource('{chainId}')
     gnosisOnChain.addMethod('POST', runSORIntegration);
     addCorsOptions(gnosis);
+
+    const sanctionsCheck = api.root.addResource('sanctions-check');
+    sanctionsCheck.addMethod('POST', sanctionsCheckIntegration);
+    addCorsOptions(sanctionsCheck);
 
     /**
      * Subdomain

--- a/index.ts
+++ b/index.ts
@@ -107,8 +107,9 @@ export class BalancerPoolsAPI extends Stack {
     });
 
     const sanctionsCheckLambda = new NodejsFunction(this, 'sanctionsCheckFunction', {
-      entry: join(__dirname, 'lambdas', 'sanctions-check.ts'),
-      ...nodeJsFunctionProps
+        entry: join(__dirname, 'lambdas', 'sanctions-check.ts'),
+        runtime: Runtime.NODEJS_14_X,
+        timeout: Duration.seconds(15)
     });
 
     /** 

--- a/lambdas/sanctions-check.ts
+++ b/lambdas/sanctions-check.ts
@@ -14,7 +14,6 @@ export const handler = async (event: any = {}): Promise<any> => {
     return { statusCode: 400, body: `Error: You are missing the address in the body` };
   }
 
-  console.log("Posting addres: ", address, " to endpoint: ", SANCTIONS_ENDPOINT);
   try {
     const response = await fetch(SANCTIONS_ENDPOINT, {
       method: 'POST',
@@ -29,11 +28,9 @@ export const handler = async (event: any = {}): Promise<any> => {
     });
 
     const result = await response.json();
-    console.log("Got result: ", result);
-
     return { statusCode: 200, body: JSON.stringify(result) };
   } catch (e) {
-    console.log(`Received error performing sanctions check: ${e}`)
+    console.log(`Received error performing sanctions check on address ${address}: ${e}`)
     return { statusCode: 500, body: '' };
   }
 };

--- a/lambdas/sanctions-check.ts
+++ b/lambdas/sanctions-check.ts
@@ -1,0 +1,28 @@
+import fetch from 'isomorphic-fetch';
+
+const SANCTIONS_ENDPOINT = 'https://api.trmlabs.com/public/v1/sanctions/screening';
+
+export const handler = async (event: any = {}): Promise<any> => {
+  if (!event.body) {
+    return { statusCode: 400, body: 'invalid request, you are missing the parameter body' };
+  }
+
+  const address = event.body.address;
+  if (!address) {
+    return { statusCode: 400, body: `Error: You are missing the address in the body` };
+  }
+
+  const response = await fetch(SANCTIONS_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify([
+      {
+        address: address.toLowerCase()
+      }
+    ])
+  });
+
+  return { statusCode: 200, body: response.json() };
+};

--- a/lambdas/sanctions-check.ts
+++ b/lambdas/sanctions-check.ts
@@ -9,9 +9,13 @@ export const handler = async (event: any = {}): Promise<any> => {
 
   const request = typeof event.body == 'object' ? event.body : JSON.parse(event.body);
 
-  const address = request.address;
-  if (!address) {
-    return { statusCode: 400, body: `Error: You are missing the address in the body` };
+  const sanctionChecks = Array.isArray(request) ? request : [request];
+
+  for (const check of sanctionChecks) {
+    const address = check.address;
+    if (!address) {
+      return { statusCode: 400, body: `Error: You are missing the address in one of your sanction checks` };
+    }
   }
 
   try {
@@ -20,17 +24,13 @@ export const handler = async (event: any = {}): Promise<any> => {
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify([
-        {
-          address: address.toLowerCase()
-        }
-      ])
+      body: JSON.stringify(sanctionChecks)
     });
 
     const result = await response.json();
     return { statusCode: 200, body: JSON.stringify(result) };
   } catch (e) {
-    console.log(`Received error performing sanctions check on address ${address}: ${e}`)
+    console.log(`Received error performing sanctions check on addresses ${sanctionChecks}: ${e}`)
     return { statusCode: 500, body: '' };
   }
 };

--- a/lambdas/sanctions-check.ts
+++ b/lambdas/sanctions-check.ts
@@ -7,22 +7,33 @@ export const handler = async (event: any = {}): Promise<any> => {
     return { statusCode: 400, body: 'invalid request, you are missing the parameter body' };
   }
 
-  const address = event.body.address;
+  const request = typeof event.body == 'object' ? event.body : JSON.parse(event.body);
+
+  const address = request.address;
   if (!address) {
     return { statusCode: 400, body: `Error: You are missing the address in the body` };
   }
 
-  const response = await fetch(SANCTIONS_ENDPOINT, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify([
-      {
-        address: address.toLowerCase()
-      }
-    ])
-  });
+  console.log("Posting addres: ", address, " to endpoint: ", SANCTIONS_ENDPOINT);
+  try {
+    const response = await fetch(SANCTIONS_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify([
+        {
+          address: address.toLowerCase()
+        }
+      ])
+    });
 
-  return { statusCode: 200, body: response.json() };
+    const result = await response.json();
+    console.log("Got result: ", result);
+
+    return { statusCode: 200, body: JSON.stringify(result) };
+  } catch (e) {
+    console.log(`Received error performing sanctions check: ${e}`)
+    return { statusCode: 500, body: '' };
+  }
 };

--- a/lambdas/sanctions-check.ts
+++ b/lambdas/sanctions-check.ts
@@ -2,9 +2,22 @@ import fetch from 'isomorphic-fetch';
 
 const SANCTIONS_ENDPOINT = 'https://api.trmlabs.com/public/v1/sanctions/screening';
 
+function formatResponse(statusCode, body) {
+  return { 
+    statusCode, 
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Headers" : "Content-Type",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "OPTIONS,POST"
+    },
+    body
+  };
+}
+
 export const handler = async (event: any = {}): Promise<any> => {
   if (!event.body) {
-    return { statusCode: 400, body: 'invalid request, you are missing the parameter body' };
+    return formatResponse(400, 'Error: invalid request, you are missing the request body');
   }
 
   const request = typeof event.body == 'object' ? event.body : JSON.parse(event.body);
@@ -14,7 +27,7 @@ export const handler = async (event: any = {}): Promise<any> => {
   for (const check of sanctionChecks) {
     const address = check.address;
     if (!address) {
-      return { statusCode: 400, body: `Error: You are missing the address in one of your sanction checks` };
+      return formatResponse(400, 'Error: You are missing the address in one of your sanction checks');
     }
   }
 
@@ -28,9 +41,10 @@ export const handler = async (event: any = {}): Promise<any> => {
     });
 
     const result = await response.json();
-    return { statusCode: 200, body: JSON.stringify(result) };
+    return formatResponse(200, JSON.stringify(result));
+   
   } catch (e) {
     console.log(`Received error performing sanctions check on addresses ${sanctionChecks}: ${e}`)
-    return { statusCode: 500, body: '' };
+    return formatResponse(500, 'Unable to perform sanctions check');
   }
 };


### PR DESCRIPTION
This lambda that can be called with the same parameters as the TRM endpoint and returns the same information. It's purpose is to ensure our user IP + address combinations are not leaked to TRM. 

You can test the lambda at: https://ayuyqhk7mh.execute-api.ap-southeast-2.amazonaws.com/prod/sanctions-check with something like:  `curl -X POST --data '{"address": "<address>"}' https://ayuyqhk7mh.execute-api.ap-southeast-2.amazonaws.com/prod/sanctions-check`

Estimated cost of running this lambda is approximately $2.30 per million requests. 