### PR TITLE
Increase SOR timeout. Add logs for pool request times

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -89,7 +89,8 @@ export class BalancerPoolsAPI extends Stack {
     const runSORLambda = new NodejsFunction(this, 'runSORFunction', {
       entry: join(__dirname, 'lambdas', 'run-sor.ts'),
       ...nodeJsFunctionProps,
-      memorySize: 256
+      memorySize: 256,
+      timeout: Duration.seconds(30)
     });
     const updatePoolsLambda = new NodejsFunction(this, 'updatePoolsFunction', {
       entry: join(__dirname, 'lambdas', 'update-pools.ts'),

--- a/src/poolDataService.ts
+++ b/src/poolDataService.ts
@@ -15,7 +15,9 @@ export class DatabasePoolDataService implements PoolDataService {
     }
 
     public async getPools(): Promise<SubgraphPoolBase[]> {
+        console.log(`Retrieving pools for chain ${this.chainId} from the database`);
         const pools = await getPools(this.chainId);
+        console.log(`Retrieved ${pools.length} pools`);
         return pools ?? [];
     }
 }


### PR DESCRIPTION
Some SOR requests are timing out after 15 seconds. Adding logs to see how much of this time is spent retrieving pools, and increasing timeout to 30 seconds. 

We could limit the pools retrieved or passed into SOR by their total liquidity so it's not calculating paths through pools with little liquidity to improve performance. 