### PR TITLE
Use SDK build 0.1.18 from Github

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@aws-cdk/aws-lambda": "^1.151.0",
         "@aws-cdk/aws-lambda-nodejs": "^1.151.0",
         "@aws-cdk/core": "^1.151.0",
-        "@balancer-labs/sdk": "^0.1.16",
+        "@balancer-labs/sdk": "github:balancer-labs/balancer-sdk#build-0.1.18",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "aws-sdk": "^2.1035.0",
@@ -2207,11 +2207,11 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.16.tgz",
-      "integrity": "sha512-hK7vN7qlXW4h/hPGdLwMASxg6XeLGpidIjGpJbml8EAgNELOMvDv2JAl/pcde3hqptmFgwRtR7yqDlDLRnkAHw==",
+      "version": "0.1.18",
+      "resolved": "git+ssh://git@github.com/balancer-labs/balancer-sdk.git#5cf4748867d44dbb2723a8334e906b045d756cbc",
+      "license": "GPL-3.0-only",
       "dependencies": {
-        "@balancer-labs/sor": "^4.0.1-beta.0",
+        "@balancer-labs/sor": "^4.0.1-beta.1",
         "@balancer-labs/typechain": "^1.0.0",
         "axios": "^0.24.0",
         "bignumber.js": "^9.0.2",
@@ -2231,9 +2231,9 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "4.0.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.0.tgz",
-      "integrity": "sha512-WhTTCwvwdbq62bMZUJjdzN2vrN2bh6NQvkiLpHJ4dPFTqFP/vdRzmx9EWO+/ln69i83pE+XvwWxPo5uQgBJJPg==",
+      "version": "4.0.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.1.tgz",
+      "integrity": "sha512-LY+qHLJxqn1cOWfKOo+mjX/85BQLQhCBP9GCsks/kXV2vLnG9HefoxcwkqP1b5bB6uFzsT67lYl9CkSFvYM/UQ==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1"
       },
@@ -10520,11 +10520,10 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.16.tgz",
-      "integrity": "sha512-hK7vN7qlXW4h/hPGdLwMASxg6XeLGpidIjGpJbml8EAgNELOMvDv2JAl/pcde3hqptmFgwRtR7yqDlDLRnkAHw==",
+      "version": "git+ssh://git@github.com/balancer-labs/balancer-sdk.git#5cf4748867d44dbb2723a8334e906b045d756cbc",
+      "from": "@balancer-labs/sdk@git+https://github.com/balancer-labs/balancer-sdk.git#build-0.1.18",
       "requires": {
-        "@balancer-labs/sor": "^4.0.1-beta.0",
+        "@balancer-labs/sor": "^4.0.1-beta.1",
         "@balancer-labs/typechain": "^1.0.0",
         "axios": "^0.24.0",
         "bignumber.js": "^9.0.2",
@@ -10534,9 +10533,9 @@
       }
     },
     "@balancer-labs/sor": {
-      "version": "4.0.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.0.tgz",
-      "integrity": "sha512-WhTTCwvwdbq62bMZUJjdzN2vrN2bh6NQvkiLpHJ4dPFTqFP/vdRzmx9EWO+/ln69i83pE+XvwWxPo5uQgBJJPg==",
+      "version": "4.0.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.1.tgz",
+      "integrity": "sha512-LY+qHLJxqn1cOWfKOo+mjX/85BQLQhCBP9GCsks/kXV2vLnG9HefoxcwkqP1b5bB6uFzsT67lYl9CkSFvYM/UQ==",
       "requires": {
         "isomorphic-fetch": "^2.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@aws-cdk/aws-lambda": "^1.151.0",
     "@aws-cdk/aws-lambda-nodejs": "^1.151.0",
     "@aws-cdk/core": "^1.151.0",
-    "@balancer-labs/sdk": "^0.1.16",
+    "@balancer-labs/sdk": "github:balancer-labs/balancer-sdk#build-0.1.18",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "aws-sdk": "^2.1035.0",


### PR DESCRIPTION
Update Balancer SDK to the latest version to handle the new graph updates. 

## Testing

Can test SOR requests against the dev endpoint: https://ayuyqhk7mh.execute-api.ap-southeast-2.amazonaws.com/prod/